### PR TITLE
add kubernetes metadata to fluentd logs; fix bug of name collision wh…

### DIFF
--- a/logging/fluentd-sidecar-es/Makefile
+++ b/logging/fluentd-sidecar-es/Makefile
@@ -1,9 +1,9 @@
 .PHONY:	build push
 
-TAG = 1.2
+TAG = v0.0.1
 
 build:
-	docker build -t gcr.io/google_containers/fluentd-sidecar-es:$(TAG) .
+	docker build -t cargo.caicloud.io/caicloud/fluentd-sidecar-es:$(TAG) .
 
 push:
-	gcloud docker push gcr.io/google_containers/fluentd-sidecar-es:$(TAG)
+	gcloud docker push cargo.caicloud.io/caicloud/fluentd-sidecar-es:$(TAG)

--- a/logging/fluentd-sidecar-es/config_generator.sh
+++ b/logging/fluentd-sidecar-es/config_generator.sh
@@ -19,19 +19,71 @@ if [ -z "$FILES_TO_COLLECT" ]; then
   exit 0
 fi
 
-for filepath in $FILES_TO_COLLECT
+read -ra filepaths <<< $FILES_TO_COLLECT
+read -ra containers <<< $CONTAINERS
+
+if [ ! ${#filepaths[@]} -eq ${#containers[@]} ]
+then
+  echo "ERROR: The number of containers is different from the number of files to collect."
+fi
+
+declare -A names_count
+
+function get_uncollided_name {
+  next_name=$1
+  base_name=$1
+  while [ ${names_count[$next_name]} ];
+  do
+    ((names_count[$base_name]++))
+    next_name=${base_name}_${names_count[$base_name]}
+  done
+  names_count+=([$next_name]=1)
+}
+
+for i in ${!filepaths[*]}
 do
-  filename=$(basename $filepath)
+  filename=$(basename ${filepaths[i]})
+  get_uncollided_name $filename
+  filename=$next_name
   cat > "/etc/td-agent/files/${filename}" << EndOfMessage
 <source>
   type tail
   format none
+  message_key log
   time_key time
-  path ${filepath}
+  path ${filepaths[i]}
   pos_file /etc/td-agent/fluentd-es.log.pos
   time_format %Y-%m-%dT%H:%M:%S
-  tag file.${filename}
+  tag kubernetes.${containers[i]}.${POD_NAME}_${NAMESPACE_NAME}_${containers[i]}.*
   read_from_head true
 </source>
+
+<filter kubernetes.${containers[i]}.**>
+@type record_transformer
+  enable_ruby true
+  auto_typecast true
+  <record>
+    kubernetes \${{"file" => "\${tag_suffix[-2]}", "pod_name" => "$POD_NAME", "namespace_name" => "$NAMESPACE_NAME", "container_name" => "${containers[i]}"}}
+  </record>
+</filter>
 EndOfMessage
 done
+
+if [ -z "$FILES_TO_ROTATE" ] || [ -z "$SIZE_LIMIT" ] || [ -z "$ROTATE_TIMES" ]; then
+  exit 0
+fi
+read -ra files_to_rotate <<<"$FILES_TO_ROTATE"
+read -ra size_limit <<<"$SIZE_LIMIT"
+read -ra rotate_times <<<"$ROTATE_TIMES"
+
+if [ ${#files_to_rotate[@]} -eq ${#size_limit[@]} ] && [ ${#files_to_rotate[@]} -eq ${#rotate_times[@]} ]; then
+  for i in ${!files_to_rotate[*]}
+  do
+    cat >> "/etc/logrotate.conf" << EndOfMessage
+${files_to_rotate[i]} {
+  size ${size_limit[i]}
+  rotate ${rotate_times[i]}
+}
+EndOfMessage
+  done
+fi

--- a/logging/fluentd-sidecar-es/td-agent.conf
+++ b/logging/fluentd-sidecar-es/td-agent.conf
@@ -12,7 +12,7 @@
 @include files/*
 
 # All the auto-generated files should use the tag "file.<filename>".
-<match file.**>
+<match kubernetes.**>
    type elasticsearch
    log_level info
    include_tag_key true


### PR DESCRIPTION
…en creating td-agent configs; allow logroate when fluentd-sidecar collecting logs

这是之前的容器内日志文件收集所用的sidecar。相比上游，做了如下修改：

1. 给日志添加了容器名、pod名、namespace这3个metadata 

2. 修复了配置名可能冲突的bug： https://github.com/kubernetes/contrib/pull/1565

3. 文件日志可以rotate https://github.com/kubernetes/contrib/pull/1567